### PR TITLE
Remove client directive from Label

### DIFF
--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import * as React from "react"
 import * as LabelPrimitive from "@radix-ui/react-label"
 


### PR DESCRIPTION
## Summary
- allow server components to import `Label` by deleting the client directive

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685b5b3bc274832c8cb935bbd63d36e6