### PR TITLE
Add Freee OAuth and company endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,17 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Freee API Integration
+
+API route handlers under `src/app/api/freee/` implement a simple OAuth flow for
+Freee Accounting. Configure the following environment variables before running
+the development server:
+
+- `FREEE_CLIENT_ID`
+- `FREEE_CLIENT_SECRET`
+- `FREEE_REDIRECT_URI`
+
+Access `/api/freee/auth` to begin authorization. After the callback completes,
+the acquired access token is stored in an HTTP-only cookie and `/api/freee/companies`
+returns the authenticated company's information.

--- a/src/app/api/freee/auth/route.ts
+++ b/src/app/api/freee/auth/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server'
+
+export async function GET() {
+  const clientId = process.env.FREEE_CLIENT_ID
+  const redirectUri = process.env.FREEE_REDIRECT_URI
+
+  if (!clientId || !redirectUri) {
+    return NextResponse.json(
+      { error: 'Missing FREEE_CLIENT_ID or FREEE_REDIRECT_URI' },
+      { status: 500 }
+    )
+  }
+
+  const authorizeUrl = new URL(
+    'https://accounts.secure.freee.co.jp/public_api/authorize'
+  )
+  authorizeUrl.searchParams.set('response_type', 'code')
+  authorizeUrl.searchParams.set('client_id', clientId)
+  authorizeUrl.searchParams.set('redirect_uri', redirectUri)
+  authorizeUrl.searchParams.set('scope', 'read write')
+  authorizeUrl.searchParams.set('state', crypto.randomUUID())
+
+  return NextResponse.redirect(authorizeUrl.toString())
+}

--- a/src/app/api/freee/callback/route.ts
+++ b/src/app/api/freee/callback/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url)
+  const code = searchParams.get('code')
+
+  if (!code) {
+    return NextResponse.json({ error: 'Missing code' }, { status: 400 })
+  }
+
+  const clientId = process.env.FREEE_CLIENT_ID
+  const clientSecret = process.env.FREEE_CLIENT_SECRET
+  const redirectUri = process.env.FREEE_REDIRECT_URI
+
+  if (!clientId || !clientSecret || !redirectUri) {
+    return NextResponse.json(
+      { error: 'Missing freee API credentials' },
+      { status: 500 }
+    )
+  }
+
+  const tokenRes = await fetch(
+    'https://accounts.secure.freee.co.jp/public_api/token',
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded'
+      },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        code,
+        client_id: clientId,
+        client_secret: clientSecret,
+        redirect_uri: redirectUri
+      }).toString()
+    }
+  )
+
+  if (!tokenRes.ok) {
+    const error = await tokenRes.text()
+    return NextResponse.json({ error }, { status: tokenRes.status })
+  }
+
+  const data = await tokenRes.json()
+  const response = NextResponse.json(data)
+
+  if (data.access_token) {
+    response.cookies.set('freee_token', data.access_token, {
+      httpOnly: true,
+      path: '/'
+    })
+  }
+
+  return response
+}

--- a/src/app/api/freee/companies/route.ts
+++ b/src/app/api/freee/companies/route.ts
@@ -1,0 +1,23 @@
+import { cookies } from 'next/headers'
+import { NextResponse } from 'next/server'
+
+export async function GET() {
+  const token = cookies().get('freee_token')?.value
+  if (!token) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const res = await fetch('https://api.freee.co.jp/api/1/companies', {
+    headers: {
+      Authorization: `Bearer ${token}`
+    }
+  })
+
+  if (!res.ok) {
+    const error = await res.text()
+    return NextResponse.json({ error }, { status: res.status })
+  }
+
+  const data = await res.json()
+  return NextResponse.json(data)
+}


### PR DESCRIPTION
## Summary
- connect to Freee Accounting API
- implement OAuth authorization and callback handlers
- add company info retrieval endpoint
- document environment variables and flow in README

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b5bdab46c832c98aad98d3c636887